### PR TITLE
feat: advanced gradient controls with multi-stop, angle, type, and noise

### DIFF
--- a/src/components/CanvasPreview/ScreenshotCard.tsx
+++ b/src/components/CanvasPreview/ScreenshotCard.tsx
@@ -110,6 +110,19 @@ export const ScreenshotCard = ({
         aspectRatio: `${exportSize.width}/${exportSize.height}`,
       }}
     >
+      {/* Noise overlay */}
+      {(screenshot.backgroundNoise ?? 0) > 0 && (
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
+            backgroundRepeat: "repeat",
+            opacity: screenshot.backgroundNoise / 100,
+            mixBlendMode: "overlay",
+          }}
+        />
+      )}
+
       {/* Remove button */}
       {canRemove && <RemoveButton onRemove={onRemove} />}
 

--- a/src/components/RightSidebar/AppearanceSection.tsx
+++ b/src/components/RightSidebar/AppearanceSection.tsx
@@ -8,6 +8,7 @@ import { ChevronDown } from "lucide-react";
 import type { Screenshot, GradientPreset } from "../../types";
 import { SidebarSection } from "./SidebarSection";
 import { BackgroundPicker } from "./BackgroundPicker";
+import { HexColorInput } from "./HexColorInput";
 import { STYLES } from "./constants";
 
 interface AppearanceSectionProps {
@@ -46,11 +47,9 @@ export const AppearanceSection = ({
       {/* Text Color */}
       <div>
         <label className="block text-xs text-gray-400 mb-1">Text Color</label>
-        <input
-          type="color"
+        <HexColorInput
           value={screenshot.textColor}
-          onChange={(e) => onUpdateScreenshot({ textColor: e.target.value })}
-          className={STYLES.colorInput}
+          onChange={(color) => onUpdateScreenshot({ textColor: color })}
         />
       </div>
 

--- a/src/components/RightSidebar/BackgroundPicker.tsx
+++ b/src/components/RightSidebar/BackgroundPicker.tsx
@@ -1,11 +1,13 @@
 /**
  * BackgroundPicker Component
  *
- * Background mode and color/gradient selection.
+ * Background mode and color/gradient selection with multi-stop gradient support.
  */
 
-import type { Screenshot, GradientPreset } from "../../types";
-import { STYLES } from "./constants";
+import { Plus, X } from "lucide-react";
+import type { Screenshot, GradientPreset, GradientStop } from "../../types";
+import { HexColorInput } from "./HexColorInput";
+import { STYLES, SLIDER_RANGES } from "./constants";
 
 interface BackgroundPickerProps {
   /** Active screenshot data */
@@ -16,73 +18,278 @@ interface BackgroundPickerProps {
   onUpdateScreenshot: (updates: Partial<Screenshot>) => void;
 }
 
+const generateStopId = () => Math.random().toString(36).substring(2, 9);
+
 /**
- * BackgroundPicker - Background style selector
- *
- * Toggle between solid color and gradient backgrounds.
- *
- * @param props - Component props
+ * Interpolate between two hex colors at a given ratio (0-1).
  */
+const interpolateColor = (c1: string, c2: string, t: number): string => {
+  const hex = (s: string) => parseInt(s, 16);
+  const r1 = hex(c1.slice(1, 3)),
+    g1 = hex(c1.slice(3, 5)),
+    b1 = hex(c1.slice(5, 7));
+  const r2 = hex(c2.slice(1, 3)),
+    g2 = hex(c2.slice(3, 5)),
+    b2 = hex(c2.slice(5, 7));
+  const r = Math.round(r1 + (r2 - r1) * t);
+  const g = Math.round(g1 + (g2 - g1) * t);
+  const b = Math.round(b1 + (b2 - b1) * t);
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+};
+
 export const BackgroundPicker = ({
   screenshot,
   gradientPresets,
   onUpdateScreenshot,
-}: BackgroundPickerProps) => (
-  <div>
-    <label className="block text-xs text-gray-400 mb-1">Background</label>
-    <div className="space-y-2">
-      {/* Mode toggle */}
-      <div className="flex gap-2">
-        <button
-          onClick={() => onUpdateScreenshot({ backgroundMode: "solid" })}
-          className={`${STYLES.modeButton} ${
-            screenshot.backgroundMode === "solid"
-              ? STYLES.modeButtonActive
-              : STYLES.modeButtonInactive
-          }`}
-        >
-          Solid
-        </button>
-        <button
-          onClick={() => onUpdateScreenshot({ backgroundMode: "gradient" })}
-          className={`${STYLES.modeButton} ${
-            screenshot.backgroundMode === "gradient"
-              ? STYLES.modeButtonActive
-              : STYLES.modeButtonInactive
-          }`}
-        >
-          Gradient
-        </button>
-      </div>
+}: BackgroundPickerProps) => {
+  const isLinear = (screenshot.gradientType ?? "linear") === "linear";
+  const stops: GradientStop[] =
+    screenshot.gradientStops && screenshot.gradientStops.length >= 2
+      ? screenshot.gradientStops
+      : [
+          { id: "s1", color: screenshot.gradientFrom ?? "#ff7e5f", position: 0 },
+          { id: "s2", color: screenshot.gradientTo ?? "#feb47b", position: 100 },
+        ];
+  const sortedStops = [...stops].sort((a, b) => a.position - b.position);
 
-      {/* Color picker or gradient presets */}
-      {screenshot.backgroundMode === "solid" ? (
-        <input
-          type="color"
-          value={screenshot.backgroundColor}
-          onChange={(e) =>
-            onUpdateScreenshot({ backgroundColor: e.target.value })
-          }
-          className={STYLES.colorInput}
-        />
-      ) : (
-        <div className="grid grid-cols-3 gap-1">
-          {gradientPresets.map((preset) => (
-            <button
-              key={preset.id}
-              onClick={() => onUpdateScreenshot({ gradientPresetId: preset.id })}
-              className={`${STYLES.gradientButton} ${
-                screenshot.gradientPresetId === preset.id
-                  ? STYLES.gradientButtonActive
-                  : ""
-              }`}
-              style={{
-                background: `linear-gradient(135deg, ${preset.from}, ${preset.to})`,
-              }}
-            />
-          ))}
+  const updateStops = (newStops: GradientStop[]) => {
+    onUpdateScreenshot({
+      gradientStops: newStops,
+      gradientFrom: newStops[0]?.color,
+      gradientTo: newStops[newStops.length - 1]?.color,
+      gradientPresetId: null,
+    });
+  };
+
+  const updateStopColor = (id: string, color: string) => {
+    updateStops(stops.map((s) => (s.id === id ? { ...s, color } : s)));
+  };
+
+  const updateStopPosition = (id: string, position: number) => {
+    const clamped = Math.max(0, Math.min(100, position));
+    updateStops(stops.map((s) => (s.id === id ? { ...s, position: clamped } : s)));
+  };
+
+  const removeStop = (id: string) => {
+    if (stops.length <= 2) return;
+    updateStops(stops.filter((s) => s.id !== id));
+  };
+
+  const addStop = () => {
+    // Find the widest gap between sorted stops and insert there
+    let maxGap = 0;
+    let insertIdx = 0;
+    for (let i = 0; i < sortedStops.length - 1; i++) {
+      const gap = sortedStops[i + 1].position - sortedStops[i].position;
+      if (gap > maxGap) {
+        maxGap = gap;
+        insertIdx = i;
+      }
+    }
+    const left = sortedStops[insertIdx];
+    const right = sortedStops[insertIdx + 1];
+    const midPosition = Math.round((left.position + right.position) / 2);
+    const midColor = interpolateColor(left.color, right.color, 0.5);
+    updateStops([
+      ...stops,
+      { id: generateStopId(), color: midColor, position: midPosition },
+    ]);
+  };
+
+  // Build gradient CSS for preview bar
+  const gradientPreview = (() => {
+    const colorStops = sortedStops
+      .map((s) => `${s.color} ${s.position}%`)
+      .join(", ");
+    return `linear-gradient(90deg, ${colorStops})`;
+  })();
+
+  return (
+    <div>
+      <label className="block text-xs text-gray-400 mb-1">Background</label>
+      <div className="space-y-2">
+        {/* Mode toggle */}
+        <div className="flex gap-2">
+          <button
+            onClick={() => onUpdateScreenshot({ backgroundMode: "solid" })}
+            className={`${STYLES.modeButton} ${
+              screenshot.backgroundMode === "solid"
+                ? STYLES.modeButtonActive
+                : STYLES.modeButtonInactive
+            }`}
+          >
+            Solid
+          </button>
+          <button
+            onClick={() => onUpdateScreenshot({ backgroundMode: "gradient" })}
+            className={`${STYLES.modeButton} ${
+              screenshot.backgroundMode === "gradient"
+                ? STYLES.modeButtonActive
+                : STYLES.modeButtonInactive
+            }`}
+          >
+            Gradient
+          </button>
         </div>
-      )}
+
+        {/* Color picker or gradient controls */}
+        {screenshot.backgroundMode === "solid" ? (
+          <HexColorInput
+            value={screenshot.backgroundColor}
+            onChange={(color) =>
+              onUpdateScreenshot({ backgroundColor: color })
+            }
+          />
+        ) : (
+          <div className="space-y-2">
+            {/* Gradient type toggle */}
+            <div className="flex gap-2">
+              <button
+                onClick={() =>
+                  onUpdateScreenshot({ gradientType: "linear" })
+                }
+                className={`${STYLES.modeButton} ${
+                  isLinear
+                    ? STYLES.modeButtonActive
+                    : STYLES.modeButtonInactive
+                }`}
+              >
+                Linear
+              </button>
+              <button
+                onClick={() =>
+                  onUpdateScreenshot({ gradientType: "radial" })
+                }
+                className={`${STYLES.modeButton} ${
+                  !isLinear
+                    ? STYLES.modeButtonActive
+                    : STYLES.modeButtonInactive
+                }`}
+              >
+                Radial
+              </button>
+            </div>
+
+            {/* Gradient presets */}
+            <div className="grid grid-cols-3 gap-1">
+              {gradientPresets.map((preset) => (
+                <button
+                  key={preset.id}
+                  onClick={() =>
+                    onUpdateScreenshot({
+                      gradientPresetId: preset.id,
+                      gradientFrom: preset.from,
+                      gradientTo: preset.to,
+                      gradientStops: preset.stops.map((s) => ({ ...s, id: generateStopId() })),
+                    })
+                  }
+                  className={`${STYLES.gradientButton} ${
+                    screenshot.gradientPresetId === preset.id
+                      ? STYLES.gradientButtonActive
+                      : ""
+                  }`}
+                  style={{
+                    background: `linear-gradient(135deg, ${preset.from}, ${preset.to})`,
+                  }}
+                />
+              ))}
+            </div>
+
+            {/* Gradient preview bar */}
+            <div
+              className="h-3 rounded-md border border-white/10"
+              style={{ background: gradientPreview }}
+            />
+
+            {/* Gradient stops */}
+            <div className="space-y-1.5">
+              {sortedStops.map((stop) => (
+                <div key={stop.id} className="flex items-center gap-1.5">
+                  <HexColorInput
+                    compact
+                    value={stop.color}
+                    onChange={(color) => updateStopColor(stop.id, color)}
+                  />
+                  <div className="flex items-center shrink-0">
+                    <input
+                      type="number"
+                      min={0}
+                      max={100}
+                      value={stop.position}
+                      onChange={(e) =>
+                        updateStopPosition(stop.id, Number(e.target.value))
+                      }
+                      className="w-8 bg-transparent text-[10px] text-gray-500 text-right outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                    />
+                    <span className="text-[10px] text-gray-500">%</span>
+                  </div>
+                  {stops.length > 2 && (
+                    <button
+                      onClick={() => removeStop(stop.id)}
+                      className="p-0.5 text-gray-500 hover:text-red-400 shrink-0"
+                    >
+                      <X size={12} />
+                    </button>
+                  )}
+                </div>
+              ))}
+              <button
+                onClick={addStop}
+                className="flex items-center gap-1 text-[10px] text-gray-500 hover:text-gray-300 transition-colors"
+              >
+                <Plus size={12} />
+                Add stop
+              </button>
+            </div>
+
+            {/* Angle slider (linear only) */}
+            {isLinear && (
+              <label className="block">
+                <div className="flex justify-between items-center mb-0.5">
+                  <span className="text-[10px] text-gray-500">Angle</span>
+                  <span className="text-[10px] text-gray-500">
+                    {screenshot.gradientAngle ?? 180}&deg;
+                  </span>
+                </div>
+                <input
+                  type="range"
+                  min={SLIDER_RANGES.gradientAngle.min}
+                  max={SLIDER_RANGES.gradientAngle.max}
+                  value={screenshot.gradientAngle ?? 180}
+                  onChange={(e) =>
+                    onUpdateScreenshot({
+                      gradientAngle: Number(e.target.value),
+                    })
+                  }
+                  className={STYLES.rangeSlider}
+                />
+              </label>
+            )}
+          </div>
+        )}
+
+        {/* Noise overlay */}
+        <label className="block">
+          <div className="flex justify-between items-center mb-0.5">
+            <span className="text-[10px] text-gray-500">Noise</span>
+            <span className="text-[10px] text-gray-500">
+              {screenshot.backgroundNoise ?? 0}%
+            </span>
+          </div>
+          <input
+            type="range"
+            min={SLIDER_RANGES.backgroundNoise.min}
+            max={SLIDER_RANGES.backgroundNoise.max}
+            value={screenshot.backgroundNoise ?? 0}
+            onChange={(e) =>
+              onUpdateScreenshot({
+                backgroundNoise: Number(e.target.value),
+              })
+            }
+            className={STYLES.rangeSlider}
+          />
+        </label>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/components/RightSidebar/HexColorInput.tsx
+++ b/src/components/RightSidebar/HexColorInput.tsx
@@ -1,0 +1,129 @@
+/**
+ * HexColorInput Component
+ *
+ * Color picker with a swatch and editable hex text input.
+ */
+
+import { useState, useEffect, useRef } from "react";
+
+interface HexColorInputProps {
+  value: string;
+  onChange: (color: string) => void;
+  className?: string;
+  /** Render as a small inline swatch + input (for shadow color, etc.) */
+  compact?: boolean;
+}
+
+const isValidHex = (v: string) => /^#[0-9a-fA-F]{6}$/.test(v);
+
+const normalizeHex = (v: string) => {
+  let hex = v.startsWith("#") ? v : `#${v}`;
+  // Expand shorthand (#abc → #aabbcc)
+  if (/^#[0-9a-fA-F]{3}$/.test(hex)) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  return hex;
+};
+
+export const HexColorInput = ({
+  value,
+  onChange,
+  className = "",
+  compact = false,
+}: HexColorInputProps) => {
+  const [draft, setDraft] = useState(value);
+  const [isFocused, setIsFocused] = useState(false);
+  const colorRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isFocused) {
+      setDraft(value);
+    }
+  }, [value, isFocused]);
+
+  const commit = () => {
+    const hex = normalizeHex(draft);
+    if (isValidHex(hex)) {
+      onChange(hex.toLowerCase());
+    }
+    setDraft(isValidHex(hex) ? hex.toLowerCase() : value);
+  };
+
+  if (compact) {
+    return (
+      <div className={`flex items-center gap-1.5 ${className}`}>
+        <button
+          type="button"
+          onClick={() => colorRef.current?.click()}
+          className="w-6 h-6 rounded border border-white/10 shrink-0 cursor-pointer"
+          style={{ backgroundColor: value }}
+        />
+        <input
+          ref={colorRef}
+          type="color"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="sr-only"
+        />
+        <input
+          type="text"
+          value={isFocused ? draft : value}
+          onFocus={() => {
+            setIsFocused(true);
+            setDraft(value);
+          }}
+          onBlur={() => {
+            setIsFocused(false);
+            commit();
+          }}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              commit();
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          className="w-[4.5rem] bg-[#2a2a2a] text-white text-xs rounded px-1.5 py-1 border border-white/10 outline-none focus:border-white/30 font-mono"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <button
+        type="button"
+        onClick={() => colorRef.current?.click()}
+        className="w-8 h-8 rounded-md border border-white/10 shrink-0 cursor-pointer"
+        style={{ backgroundColor: value }}
+      />
+      <input
+        ref={colorRef}
+        type="color"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="sr-only"
+      />
+      <input
+        type="text"
+        value={isFocused ? draft : value}
+        onFocus={() => {
+          setIsFocused(true);
+          setDraft(value);
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+          commit();
+        }}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            commit();
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        className="flex-1 bg-[#2a2a2a] text-white text-xs rounded-md px-2 py-1.5 border border-white/10 outline-none focus:border-white/30 font-mono"
+      />
+    </div>
+  );
+};

--- a/src/components/RightSidebar/ShadowControls.tsx
+++ b/src/components/RightSidebar/ShadowControls.tsx
@@ -6,7 +6,8 @@
 
 import { Toggle } from "./Toggle";
 import { RangeSlider } from "./RangeSlider";
-import { STYLES, SLIDER_RANGES } from "./constants";
+import { HexColorInput } from "./HexColorInput";
+import { SLIDER_RANGES } from "./constants";
 import type { ShadowControlsProps } from "./types";
 
 /**
@@ -38,12 +39,11 @@ export const ShadowControls = ({
     {shadow.enabled && (
       <>
         <div className="flex items-center gap-2">
-          <span className={STYLES.labelSmall}>Color</span>
-          <input
-            type="color"
+          <span className="text-xs text-gray-500">Color</span>
+          <HexColorInput
             value={shadow.color}
-            onChange={(e) => onColorChange(e.target.value)}
-            className={STYLES.colorInputSmall}
+            onChange={onColorChange}
+            compact
           />
         </div>
 

--- a/src/components/RightSidebar/constants.ts
+++ b/src/components/RightSidebar/constants.ts
@@ -118,4 +118,6 @@ export const SLIDER_RANGES = {
   imageRotation: { min: 0, max: 360 },
   device3dRotateY: { min: -45, max: 45 },
   device3dRotateX: { min: -30, max: 30 },
+  gradientAngle: { min: 0, max: 360 },
+  backgroundNoise: { min: 0, max: 100 },
 } as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -235,12 +235,12 @@ export const devices: DeviceSpec[] = [
 ];
 
 export const gradientPresets: GradientPreset[] = [
-  { id: "sunset", label: "Sunset", from: "#ff7e5f", to: "#feb47b" },
-  { id: "ocean", label: "Ocean", from: "#2b5876", to: "#4e4376" },
-  { id: "mint", label: "Mint", from: "#00b09b", to: "#96c93d" },
-  { id: "berry", label: "Berry", from: "#e1eec3", to: "#f05053" },
-  { id: "royal", label: "Royal", from: "#141E30", to: "#243B55" },
-  { id: "rose", label: "Rose", from: "#f4c4f3", to: "#fc67fa" },
+  { id: "sunset", label: "Sunset", from: "#ff7e5f", to: "#feb47b", stops: [{ id: "s1", color: "#ff7e5f", position: 0 }, { id: "s2", color: "#feb47b", position: 100 }] },
+  { id: "ocean", label: "Ocean", from: "#2b5876", to: "#4e4376", stops: [{ id: "s1", color: "#2b5876", position: 0 }, { id: "s2", color: "#4e4376", position: 100 }] },
+  { id: "mint", label: "Mint", from: "#00b09b", to: "#96c93d", stops: [{ id: "s1", color: "#00b09b", position: 0 }, { id: "s2", color: "#96c93d", position: 100 }] },
+  { id: "berry", label: "Berry", from: "#e1eec3", to: "#f05053", stops: [{ id: "s1", color: "#e1eec3", position: 0 }, { id: "s2", color: "#f05053", position: 100 }] },
+  { id: "royal", label: "Royal", from: "#141E30", to: "#243B55", stops: [{ id: "s1", color: "#141E30", position: 0 }, { id: "s2", color: "#243B55", position: 100 }] },
+  { id: "rose", label: "Rose", from: "#f4c4f3", to: "#fc67fa", stops: [{ id: "s1", color: "#f4c4f3", position: 0 }, { id: "s2", color: "#fc67fa", position: 100 }] },
 ];
 
 export const exportSizes: ExportSize[] = [

--- a/src/context/EditorContext.tsx
+++ b/src/context/EditorContext.tsx
@@ -120,6 +120,15 @@ const createDefaultScreenshot = (): Screenshot => ({
   backgroundColor: "#8b5cf6",
   backgroundMode: "solid",
   gradientPresetId: null,
+  gradientFrom: "#ff7e5f",
+  gradientTo: "#feb47b",
+  gradientStops: [
+    { id: "s1", color: "#ff7e5f", position: 0 },
+    { id: "s2", color: "#feb47b", position: 100 },
+  ],
+  gradientType: "linear",
+  gradientAngle: 180,
+  backgroundNoise: 0,
   textColor: "#ffffff",
   headlineX: 50,
   headlineY: 10,
@@ -379,6 +388,12 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
       backgroundColor: activeScreenshot.backgroundColor,
       backgroundMode: activeScreenshot.backgroundMode,
       gradientPresetId: activeScreenshot.gradientPresetId,
+      gradientFrom: activeScreenshot.gradientFrom,
+      gradientTo: activeScreenshot.gradientTo,
+      gradientStops: activeScreenshot.gradientStops.map((s) => ({ ...s })),
+      gradientType: activeScreenshot.gradientType,
+      gradientAngle: activeScreenshot.gradientAngle,
+      backgroundNoise: activeScreenshot.backgroundNoise,
       textColor: activeScreenshot.textColor,
       headlineX: 50,
       headlineY: 10,
@@ -668,10 +683,22 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
 
   const getBackgroundStyle = (screenshot: Screenshot) => {
     if (screenshot.backgroundMode === "gradient") {
-      const preset =
-        gradientPresets.find((p) => p.id === screenshot.gradientPresetId) ??
-        gradientPresets[0];
-      return `linear-gradient(180deg, ${preset.from}, ${preset.to})`;
+      const type = screenshot.gradientType ?? "linear";
+      // Use gradientStops if available, fallback to gradientFrom/gradientTo for old data
+      const stops =
+        screenshot.gradientStops && screenshot.gradientStops.length >= 2
+          ? screenshot.gradientStops
+          : [
+              { id: "f", color: screenshot.gradientFrom ?? gradientPresets[0].from, position: 0 },
+              { id: "t", color: screenshot.gradientTo ?? gradientPresets[0].to, position: 100 },
+            ];
+      const sorted = [...stops].sort((a, b) => a.position - b.position);
+      const colorStops = sorted.map((s) => `${s.color} ${s.position}%`).join(", ");
+      if (type === "radial") {
+        return `radial-gradient(circle at center, ${colorStops})`;
+      }
+      const angle = screenshot.gradientAngle ?? 180;
+      return `linear-gradient(${angle}deg, ${colorStops})`;
     }
     return screenshot.backgroundColor;
   };

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -436,17 +436,67 @@ export const exportScreenshots = async ({
 
     // Draw background
     if (screenshot.backgroundMode === "gradient") {
-      const preset =
-        gradientPresets.find((p) => p.id === screenshot.gradientPresetId) ??
-        gradientPresets[0];
-      const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
-      gradient.addColorStop(0, preset.from);
-      gradient.addColorStop(1, preset.to);
+      const from = screenshot.gradientFrom ?? gradientPresets[0].from;
+      const to = screenshot.gradientTo ?? gradientPresets[0].to;
+      const type = screenshot.gradientType ?? "linear";
+      let gradient: CanvasGradient;
+      if (type === "radial") {
+        const cx = canvas.width / 2;
+        const cy = canvas.height / 2;
+        const radius = Math.max(canvas.width, canvas.height) / 2;
+        gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius);
+      } else {
+        const angle = screenshot.gradientAngle ?? 180;
+        const angleRad = ((angle - 90) * Math.PI) / 180;
+        const cx = canvas.width / 2;
+        const cy = canvas.height / 2;
+        const len = Math.max(canvas.width, canvas.height) / 2;
+        gradient = ctx.createLinearGradient(
+          cx - Math.cos(angleRad) * len,
+          cy - Math.sin(angleRad) * len,
+          cx + Math.cos(angleRad) * len,
+          cy + Math.sin(angleRad) * len,
+        );
+      }
+      // Use gradientStops if available, fallback to from/to for old data
+      const stops =
+        screenshot.gradientStops && screenshot.gradientStops.length >= 2
+          ? [...screenshot.gradientStops].sort((a, b) => a.position - b.position)
+          : [
+              { id: "f", color: from, position: 0 },
+              { id: "t", color: to, position: 100 },
+            ];
+      for (const stop of stops) {
+        gradient.addColorStop(stop.position / 100, stop.color);
+      }
       ctx.fillStyle = gradient;
     } else {
       ctx.fillStyle = screenshot.backgroundColor;
     }
     ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    // Draw noise overlay
+    const noise = screenshot.backgroundNoise ?? 0;
+    if (noise > 0) {
+      const noiseCanvas = document.createElement("canvas");
+      noiseCanvas.width = canvas.width;
+      noiseCanvas.height = canvas.height;
+      const noiseCtx = noiseCanvas.getContext("2d")!;
+      const imageData = noiseCtx.createImageData(canvas.width, canvas.height);
+      const data = imageData.data;
+      for (let i = 0; i < data.length; i += 4) {
+        const v = Math.random() * 255;
+        data[i] = v;
+        data[i + 1] = v;
+        data[i + 2] = v;
+        data[i + 3] = 255;
+      }
+      noiseCtx.putImageData(imageData, 0, 0);
+      ctx.save();
+      ctx.globalAlpha = noise / 100;
+      ctx.drawImage(noiseCanvas, 0, 0);
+      ctx.restore();
+    }
 
     // Get font family
     const fontFamily = `'${screenshot.fontFamily}', sans-serif`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,11 +36,18 @@ export type DeviceSpec = {
   colors: DeviceColor[];
 };
 
+export type GradientStop = {
+  id: string;
+  color: string;
+  position: number; // 0-100
+};
+
 export type GradientPreset = {
   id: string;
   label: string;
   from: string;
   to: string;
+  stops: GradientStop[];
 };
 
 export type ImageOverlay = {
@@ -63,6 +70,12 @@ export type Screenshot = {
   backgroundColor: string;
   backgroundMode: "solid" | "gradient" | "image";
   gradientPresetId: string | null;
+  gradientFrom: string;
+  gradientTo: string;
+  gradientStops: GradientStop[];
+  gradientType: "linear" | "radial";
+  gradientAngle: number;
+  backgroundNoise: number;
   textColor: string;
   headlineX: number;
   headlineY: number;


### PR DESCRIPTION
- Add GradientStop type and multi-stop gradient support to Screenshot
- Replace native color inputs with HexColorInput component throughout
- Add gradient type toggle (linear/radial), angle slider, and noise overlay
- Update gradient presets with explicit stop data
- Update canvas export to render multi-stop gradients and noise

<img width="321" height="583" alt="CleanShot 2026-03-03 at 20 12 28" src="https://github.com/user-attachments/assets/654a06ce-5248-4028-9817-1b89ff7450dd" />
