### PR TITLE
build: add docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+node_modules
+dist
+dist-ssr
+.env
+*.local
+.vscode
+.tanstack
+.nitro
+.wrangler
+count.txt
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# --- build stage ---------------------------------------------------------
+FROM oven/bun:1-alpine AS build
+
+WORKDIR /app
+
+# Install dependencies first so they stay cached across source changes
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+RUN bun run build
+
+# --- runtime stage -------------------------------------------------------
+FROM nginx:1.27-alpine AS runtime
+
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://127.0.0.1/ >/dev/null || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -114,6 +114,27 @@ bun run build
 
 The built files will be in the `dist/` directory.
 
+### 🐳 Self-Hosting with Docker
+
+The app is fully client-side — no backend, no database, no API keys. Everything you need to
+run it yourself is in `docker-compose.yml`:
+
+```bash
+docker compose up -d --build
+```
+
+Then open [http://localhost:8080](http://localhost:8080).
+
+To use a different port, set `APPSHOTS_PORT`:
+
+```bash
+APPSHOTS_PORT=3000 docker compose up -d --build
+```
+
+The build is a two-stage image: Bun compiles the site to static files, and nginx serves them
+with SPA routing fallback and long-lived caching for hashed assets. Pull new changes and
+re-run `docker compose up -d --build` to update; `docker compose down` stops it.
+
 ## 🛠️ Tech Stack
 
 - **Framework**: [React 19](https://react.dev/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  appshots:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: appshots:latest
+    container_name: appshots
+    restart: unless-stopped
+    ports:
+      - "${APPSHOTS_PORT:-8080}:80"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+
+    # Hashed build assets never change, so cache them hard
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # SPA fallback — the editor is a client-side route tree
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+}


### PR DESCRIPTION
Only adds docker files, still uses localStorage to store projects.

Follow-up: make the self-hosted instance use a database so projects carry over between sessions